### PR TITLE
Added default_state, duration, and invert options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,61 @@ The raspberry pi can then control the state of the relays
 
 1. Install homebridge using: `sudo npm install --unsafe-perm -g homebridge`
 2. Install this plugin using: `sudo npm install -g --unsafe-perm homebridge-relays`
-3. Update your configuration file. See `config.json` in this repository for a sample.
+3. Update your configuration file. See `config-sample.json` in this repository for a sample.
+
+# Sample Configuration
+
+    {
+      "bridge": {
+        "name": "RelayServer",
+        "username": "CC:22:3D:E3:CE:FA",
+        "port": 51826,
+        "pin": "031-45-155"
+      },
+
+      "description": "4 Channel Relay",
+
+      "accessories": [
+        {
+          "accessory": "Relay",
+          "name": "Relay-1",
+          "pin": 11
+          "invert": true,
+          "default_state": false,
+          "duration": 1000
+        },
+        {
+          "accessory": "Relay",
+          "name": "Relay-2",
+          "pin": 13
+          "invert": false,
+          "default_state": false,
+          "duration": 3600000
+        },
+        {
+          "accessory": "Relay",
+          "name": "Relay-3",
+          "pin": 15
+        },
+        {
+          "accessory": "Relay",
+          "name": "Relay-4",
+          "pin": 29
+        }
+      ],
+
+      "platforms": []
+    }
+
+# Accessory Configuration Options
+
+Name             | Meaning
+---------------- | ------------------------------------------------
+`accessory`      | Accessory type. `Relay` (REQUIRED)
+`name`           | Default name for the accessory. (REQUIRED)
+`pin`            | Which pin number to use for this accessory. (REQUIRED)
+`invert`         | If true, output on pin is `LOW` for `ON`, and `HIGH` for `OFF`. (Default: false)
+`default_state` | State to set on start of homebridge.  `true` for `ON`, `false` for `OFF`. (Default: `false`/`OFF`)
+`duration_ms`   | If given, accessory will stay ON for this many milliseconds, then turn OFF.  Timer resets if accessory is turned ON again while it is still ON. (Default: 0/None)
+
+

--- a/config-sample.json
+++ b/config-sample.json
@@ -12,7 +12,10 @@
     {
       "accessory": "Relay",
       "name": "Relay-1",
-      "pin": 11
+      "pin": 11,
+      "invert": true,
+      "default_state": false,
+      "duration_ms": 1000
     },
     {
       "accessory": "Relay",

--- a/index.js
+++ b/index.js
@@ -10,29 +10,58 @@ module.exports = function(homebridge) {
 function RelayAccessory(log, config) {
   this.log = log;
   this.name = config["name"];
-  this.binaryState = 0;
   this.pin = config["pin"];
+  this.invert = defaultVal(config["invert"], false);
+  this.default = defaultVal(config["default_state"], false);
+  this.duration = defaultVal(config["duration_ms"], 0);
+  this.timerid = -1;
 
-  this.log("Creating a relay with name '" + this.name + "'");
-  rpio.open(this.pin, rpio.OUTPUT, rpio.LOW);
+  if (!this.pin) throw new Error("You must provide a config value for 'pin'.");
+  if (!is_int(this.pin)) throw new Error("You must provide an integer config value for 'pin'.");
+  if (!is_int(this.duration)) throw new Error("The config value 'duration' must be an integer number of milliseconds.");
+
+  this.log("Creating a relay named '%s', initial state: %s", this.name, (this.default? "ON" : "OFF"));
+  rpio.open(this.pin, rpio.OUTPUT, this.gpioVal(this.default));
 }
 
 RelayAccessory.prototype.getRelayStatus = function(callback) {
-  this.binaryState = rpio.read(this.pin);
-  var relayOn = this.binaryState > 0;
-  callback(null, relayOn);
+  callback(null, this.readState());
 }
 
-RelayAccessory.prototype.setRelayOn = function(on, callback) {
-  this.binaryState = on ? 1 : 0;
-  if (this.binaryState) {
-    rpio.write(this.pin, rpio.LOW);
-  } else {
-    rpio.write(this.pin, rpio.HIGH);
+RelayAccessory.prototype.setRelayOn = function(newState, callback) {
+  if (this.timerid !== -1) {
+    clearTimeout(this.timerid);
+    this.timerid = -1;
   }
 
-  this.log("Relay status for PIN:'%d' is %s", this.name, this.binaryState);
+  this.setState(newState);
+  this.log("Relay status for '%s', pin %d is %s", this.name, this.pin, newState);
+
+  if (newState && this.duration > 0) {
+    this.timerid = setTimeout(this.timeOutCB, this.duration, this);
+  }
+
   callback(null);
+}
+
+RelayAccessory.prototype.timeOutCB = function(o) {
+  o.setState(false);
+  o.log("Relay for '%s', pin %d timed out.", o.name, o.pin);
+  o.timerid = -1;
+}
+
+RelayAccessory.prototype.readState = function() {
+  var val = this.gpioVal(rpio.read(this.pin) > 0);
+  return val == rpio.HIGH;
+}
+
+RelayAccessory.prototype.setState = function(val) {
+  rpio.write(this.pin, this.gpioVal(val));
+}
+
+RelayAccessory.prototype.gpioVal = function(val) {
+  if (this.invert) val = !val;
+  return val? rpio.HIGH : rpio.LOW;
 }
 
 RelayAccessory.prototype.getServices = function() {
@@ -42,3 +71,16 @@ RelayAccessory.prototype.getServices = function() {
     .on('set', this.setRelayOn.bind(this));
   return [relayService];
 }
+
+var is_int = function(n) {
+  return n % 1 === 0;
+}
+
+var is_defined = function(v) {
+  return typeof v !== 'undefined';
+}
+
+var defaultVal = function(v, dflt) {
+  return is_defined(v)? v : dflt;
+}
+


### PR DESCRIPTION
This makes this plugin useful for the relays I need to control to turn my gas fireplace on and off.  Adds three accessory options:

Option | Use
------- | ----------
default_state | The state to set the device to when homebridge starts.  `false` for OFF, `true` for ON.
duration_ms | Turns accessory back off after this many milliseconds after it is turned on.  Timer resets if state is set again. I use it to turn my fireplace off after an hour.
invert | If true, output on pin will be LOW for ON, and HIGH for OFF.
