### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,15 @@ The raspberry pi can then control the state of the relays
         {
           "accessory": "Relay",
           "name": "Relay-3",
-          "pin": 15
+          "pin": 15,
+          "repeatAfter": 300,
+          "default_state": false
         },
         {
           "accessory": "Relay",
           "name": "Relay-4",
-          "pin": 29
+          "pin": 29,
+          "2ndPin" : 34
         }
       ],
 


### PR DESCRIPTION
Hi Team, 
I just updated my Hoobs for Version 4.0.31 and the Relay Lapo didn't work any more, baucause one of the library in the new Hoobs environment was updated. Please can you help here on the update or to certificate this plug in for Hoobs. I use the relays for the Jalousie to manage via Homebridge. Thanks for your help. 
BR André 